### PR TITLE
Added removal and reinsertion of pagespeed module due to incorrect Go…

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,28 @@
 ---
+# Pagespeed module is failing on apt-cache update
+# bodging in a fix from https://support.plesk.com/hc/en-us/articles/360021566754--apt-update-is-not-working-on-Plesk-server-with-Ubuntu-or-Debian-after-installing-PageSpeed-Apache-module-through-Google-PageSpeed-Insights-extension-The-repository-http-dl-google-com-linux-mod-pagespeed-deb-stable-Release-is-not-signed
+
+- name: Check pagespeed repo file exists
+  stat: path=/etc/apt/sources.list.d/mod-pagespeed.list
+  register: ps_apt_stat
+  failed_when: not ps_apt_stat.stat.exists
+
+- name: Moving out pagespeed repo
+  command: mv /etc/apt/sources.list.d/mod-pagespeed.list /tmp/
+  when: ps_apt_stat.stat.exists
+
+- name: Update the apt-cache to remove pagespeed apt from cache
+  apt: update_cache=yes cache_valid_time=3600
+
+- name: Install the latest version of the signing key
+  apt_key: 
+    url: https://dl-ssl.google.com/linux/linux_signing_key.pub 
+    state: present
+
+- name: Moving pagespeed repo back in ready for the update
+  stat: path=/tmp/mod-pagespeed.list
+  command: mv /tmp/mod-pagespeed.list /etc/apt/sources.list.d/
+
 - name: Update the apt-cache
   apt: update_cache=yes cache_valid_time=3600
 


### PR DESCRIPTION
…ogle signing key.

Pls see https://support.plesk.com/hc/en-us/articles/360021566754--apt-update-is-not-working-on-Plesk-server-with-Ubuntu-or-Debian-after-installing-PageSpeed-Apache-module-through-Google-PageSpeed-Insights-extension-The-repository-http-dl-google-com-linux-mod-pagespeed-deb-stable-Release-is-not-signed for explanation of why this is (probably) necessary.

Also https://www.gitmemory.com/issue/apache/incubator-pagespeed-mod/1872/486700223